### PR TITLE
Don't run distinct on native linking/compile flags

### DIFF
--- a/modules/cli/src/main/scala/CommandLineApp.scala
+++ b/modules/cli/src/main/scala/CommandLineApp.scala
@@ -362,7 +362,7 @@ object VcpkgCLI extends VcpkgPluginImpl, VcpkgPluginNativeImpl:
               VcpkgNativeConfig().withRenamedLibraries(rename)
             ).map(NativeFlag.Linking(_))
 
-          flags.result().distinct
+          flags.result()
         end computeNativeFlags
 
         action match


### PR DESCRIPTION
This breaks flags with parameters, such as on Mac OS:
  -framework Cocoa -framework IOKit