### PR TITLE
Fix mill-vcpkg-native plugin name

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -219,7 +219,7 @@ lazy val `mill-vcpkg-native-plugin` = projectMatrix
   .dependsOn(core, `mill-vcpkg-plugin` % "test->test;compile->compile")
   .settings(publishing)
   .settings(
-    name := "mill-vcpkg",
+    name := "mill-vcpkg-native",
     libraryDependencies += "com.lihaoyi" %% "mill-scalanativelib" % V.mill,
     libraryDependencies += "com.lihaoyi" %% "utest" % V.utest % Test,
     testFrameworks += new TestFramework("utest.runner.Framework"),


### PR DESCRIPTION
The `mill-vcpkg-native`  plugin [doesn't appear to be anywhere in maven](https://repo1.maven.org/maven2/com/indoorvivants/vcpkg/), and I bet it's due to both the native and non native versions of the plugin having the same exact name. I hope this helps :)
